### PR TITLE
Updates per new k8s version api results schema

### DIFF
--- a/app/interface/src/components/Tfvar/KubernetesCluster/index.tsx
+++ b/app/interface/src/components/Tfvar/KubernetesCluster/index.tsx
@@ -21,11 +21,11 @@ export default function KubernetesCluster() {
   // The default value that kubernetes cluster will carry.
   function defaultValue(): TfvarKubernetesClusterType {
     var defaultVersion = "";
-    kubernetesVersion?.orchestrators.forEach((o) => {
-      if (o.default) {
-        defaultVersion = o.orchestratorVersion;
-      }
-    });
+    if (kubernetesVersion && kubernetesVersion.values) {
+      defaultVersion = Object.keys(
+        kubernetesVersion.values[0].patchVersions
+      )[0];
+    }
 
     return {
       kubernetesVersion: defaultVersion,

--- a/app/interface/src/components/Tfvar/KubernetesVersion.tsx
+++ b/app/interface/src/components/Tfvar/KubernetesVersion.tsx
@@ -1,5 +1,5 @@
 import { FaChevronDown } from "react-icons/fa";
-import { Orchestrator } from "../../dataStructures";
+import { Orchestrator, Value } from "../../dataStructures";
 import { useActionStatus } from "../../hooks/useActionStatus";
 import { useLab, useSetLab } from "../../hooks/useLab";
 import { useSetLogs } from "../../hooks/useLogs";
@@ -24,11 +24,10 @@ export default function KubernetesVersion({
   } = useLab();
   const { mutate: setLab } = useSetLab();
 
-  function handleOnSelect(orchestrator: Orchestrator) {
+  function handleOnSelect(patchVersion: string) {
     if (lab !== undefined) {
       if (lab.template !== undefined) {
-        lab.template.kubernetesClusters[0].kubernetesVersion =
-          orchestrator.orchestratorVersion;
+        lab.template.kubernetesClusters[0].kubernetesVersion = patchVersion;
         !actionStatus &&
           setLogs({
             isStreaming: false,
@@ -45,13 +44,9 @@ export default function KubernetesVersion({
     lab.template.kubernetesClusters.length > 0 &&
     lab.template.kubernetesClusters[0].kubernetesVersion === "" &&
     data &&
-    data.orchestrators
+    data.values
   ) {
-    data.orchestrators.forEach((orchetrator) => {
-      if (orchetrator.default && lab.template) {
-        handleOnSelect(orchetrator);
-      }
-    });
+    handleOnSelect(Object.keys(data.values[0].patchVersions)[0]);
   }
 
   return (
@@ -82,31 +77,33 @@ export default function KubernetesVersion({
           !versionMenu && "hidden"
         } items-center gap-y-2 rounded border border-slate-500 bg-slate-100 p-2 dark:bg-slate-800`}
       >
-        {data?.orchestrators?.map(
-          (orchestrator) =>
+        {data?.values?.map(
+          (value) =>
             lab &&
             lab.template &&
             lab.template.kubernetesClusters.length > 0 &&
             lab.template?.kubernetesClusters[0].kubernetesVersion !==
               undefined && (
-              <div
-                key={orchestrator.orchestratorVersion}
-                className="flex justify-between gap-x-1"
-              >
-                <div
-                  className={`${
-                    orchestrator.orchestratorVersion ===
-                      lab.template?.kubernetesClusters[0].kubernetesVersion &&
-                    "bg-green-300 hover:text-slate-900 dark:text-slate-900"
-                  } w-full items-center justify-between rounded p-2 hover:bg-sky-500 hover:text-slate-100 `}
-                  onClick={() => {
-                    setVersionMenu(false);
-                    handleOnSelect(orchestrator);
-                  }}
-                >
-                  <div className={`flex w-full justify-between`}>
-                    {orchestrator.orchestratorVersion}
-                    <div className="justify-start">
+              <div key={value.version}>
+                {Object.keys(value.patchVersions).map((patchVersion) => (
+                  <div
+                    key={patchVersion}
+                    className="flex justify-between gap-x-1"
+                  >
+                    <div
+                      className={`${
+                        patchVersion ===
+                          lab.template?.kubernetesClusters[0]
+                            .kubernetesVersion &&
+                        "bg-green-300 hover:text-slate-900 dark:text-slate-900"
+                      } w-full items-center justify-between rounded p-2 hover:bg-sky-500 hover:text-slate-100 `}
+                      onClick={() => {
+                        setVersionMenu(false);
+                        handleOnSelect(patchVersion);
+                      }}
+                    >
+                      <div key={patchVersion}>{patchVersion}</div>
+                      {/* <div className="justify-start">
                       <span>
                         {orchestrator.isPreview
                           ? " (Preview)"
@@ -114,19 +111,18 @@ export default function KubernetesVersion({
                           ? " (Default)"
                           : ""}
                       </span>
+                    </div> */}
+
+                      <div className="space-x-2 text-xs text-slate-500">
+                        Upgrades :
+                        {value.patchVersions[patchVersion].upgrades &&
+                          value.patchVersions[patchVersion].upgrades.map(
+                            (upgrade) => <span key={upgrade}> {upgrade}</span>
+                          )}
+                      </div>
                     </div>
                   </div>
-                  <div className="space-x-2 text-xs text-slate-500">
-                    Upgrades :
-                    {orchestrator.upgrades &&
-                      orchestrator.upgrades.map((upgrade) => (
-                        <span key={upgrade.orchestratorVersion}>
-                          {" "}
-                          {upgrade.orchestratorVersion}
-                        </span>
-                      ))}
-                  </div>
-                </div>
+                ))}
               </div>
             )
         )}

--- a/app/interface/src/dataStructures.ts
+++ b/app/interface/src/dataStructures.ts
@@ -204,11 +204,15 @@ export type Privildge = {
   isMentor: boolean;
 };
 
+// export type KubernetesOrchestrators = {
+//   id: string;
+//   name: string;
+//   orchestrators: Orchestrator[];
+//   type: string;
+// };
+
 export type KubernetesOrchestrators = {
-  id: string;
-  name: string;
-  orchestrators: Orchestrator[];
-  type: string;
+  values: Value[];
 };
 
 export type Orchestrator = {
@@ -228,6 +232,23 @@ export type Upgrade = {
   orchestratorType: OrchestratorType;
   orchestratorVersion: string;
 };
+
+type PatchVersions = {
+  [key: string]: {
+    upgrades: string[];
+  };
+};
+
+export type Capabilities = {
+	SupportPlan: string[]
+}
+
+export type Value = {
+	capabilities:  Capabilities;
+	isPreview: any;
+	patchVersions: PatchVersions;
+	version: string;
+}
 
 export type ServerStatus = {
   status: "" | "OK";

--- a/app/server/entity/kversion.go
+++ b/app/server/entity/kversion.go
@@ -11,7 +11,7 @@ type Orchestrator struct {
 	IsPreview           interface{} `json:"isPreview"`
 	OrchestratorType    string      `json:"orchestratorType"`
 	OrchestratorVersion string      `json:"orchestratorVersion"`
-	Upgrades            []Upgrade   `json:"upgrades"`
+	Upgrades            []string    `json:"upgrades"`
 }
 
 type KubernetesOrchestrator struct {
@@ -21,8 +21,27 @@ type KubernetesOrchestrator struct {
 	Type          string         `json:"type"`
 }
 
+type PatchVersions map[string]struct {
+	Upgrades []string `json:"upgrades"`
+}
+
+type Capabilities struct {
+	SupportPlan []string `json:"supportPlan"`
+}
+
+type Value struct {
+	Capabilities  Capabilities  `json:"capabilities"`
+	IsPreview     interface{}   `json:"isPreview"`
+	PatchVersions PatchVersions `json:"patchVersions"`
+	Version       string        `json:"version"`
+}
+
+type KubernetesVersions struct {
+	Values []Value `json:"values"`
+}
+
 type KVersionService interface {
-	GetOrchestrator() (KubernetesOrchestrator, error)
+	GetOrchestrator() (KubernetesVersions, error)
 	GetDefaultVersion() string
 }
 

--- a/tf/kubernetes_main.tf
+++ b/tf/kubernetes_main.tf
@@ -24,6 +24,13 @@ resource "azurerm_role_assignment" "identity_operator" {
   role_definition_name = "Managed Identity Operator"
 }
 
+resource "azurerm_role_assignment" "network_contributor" {
+  count                = var.kubernetes_clusters == null ? 0 : length(var.kubernetes_clusters)
+  principal_id         = azurerm_user_assigned_identity.ccp_identity[count.index].principal_id
+  scope                = azurerm_resource_group.this.id
+  role_definition_name = "Network Contributor"
+}
+
 resource "azurerm_kubernetes_cluster" "this" {
   count                   = var.kubernetes_clusters == null ? 0 : length(var.kubernetes_clusters)
   name                    = module.naming.kubernetes_cluster.name


### PR DESCRIPTION
`az aks get-versions` was updated and the results include new schema. Had to change the code to accommodate for the change. This is a breaking change, and all servers need reboot.